### PR TITLE
Moving the tutorial files under education org

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -1,0 +1,4 @@
+# Vault on OpenShift
+
+These are the artifacts for the [Vault Installation to RedHat OpenShift via Helm](https://developer.hashicorp.com/vault/tutorials/kubernetes/kubernetes-openshift)
+tutorial. Visit the learn site for detail.

--- a/openshift/deployment-issues.yml
+++ b/openshift/deployment-issues.yml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: issues
+  labels:
+    app: issues
+spec:
+  selector:
+    matchLabels:
+      app: issues
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        vault.hashicorp.com/agent-inject: "true"
+        vault.hashicorp.com/role: "issues"
+        vault.hashicorp.com/agent-inject-secret-issues-config.txt: "secret/data/issues/config"
+        vault.hashicorp.com/agent-inject-template-issues-config.txt: |
+          {{- with secret "secret/data/issues/config" -}}
+          postgresql://{{ .Data.data.username }}:{{ .Data.data.password }}@postgres:5432/wizard
+          {{- end -}}
+      labels:
+        app: issues
+    spec:
+      serviceAccountName: issues
+      containers:
+        - name: issues
+          image: jweissig/app:0.0.1

--- a/openshift/deployment-webapp.yml
+++ b/openshift/deployment-webapp.yml
@@ -1,0 +1,29 @@
+---
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: webapp
+    labels:
+      app: webapp
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: webapp
+    template:
+      metadata:
+        labels:
+          app: webapp
+      spec:
+        serviceAccountName: webapp
+        containers:
+        - name: app
+          image: burtlo/exampleapp-ruby:k8s
+          imagePullPolicy: Always
+          env:
+          - name: VAULT_ADDR
+            value: "http://vault:8200"
+          - name: JWT_PATH
+            value: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+          - name: SERVICE_PORT
+            value: "8080"

--- a/openshift/service-account-issues.yml
+++ b/openshift/service-account-issues.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: issues

--- a/openshift/service-account-webapp.yml
+++ b/openshift/service-account-webapp.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: webapp

--- a/openshift/vault-policy-issues.hcl
+++ b/openshift/vault-policy-issues.hcl
@@ -1,0 +1,3 @@
+path "internal/data/database/config" {
+  capabilities = ["read"]
+}

--- a/openshift/vault-policy-webapp.hcl
+++ b/openshift/vault-policy-webapp.hcl
@@ -1,0 +1,3 @@
+path "secret/data/webapp/config" {
+  capabilities = ["read"]
+}


### PR DESCRIPTION
Moving the OpenShift lab files under `hashicorp-education` from `vault-guides`.